### PR TITLE
add support for Mac M1, maybe other arm64+neon as well

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "sse2neon"]
+	path = sse2neon
+	url = https://github.com/DLTcollab/sse2neon

--- a/LeopardCommon.cpp
+++ b/LeopardCommon.cpp
@@ -107,6 +107,8 @@ static void _cpuid(unsigned int cpu_info[4U], const unsigned int cpu_info_type)
 #endif
 }
 
+#elif defined(LEO_USE_SSE2NEON)
+bool CpuHasSSSE3 = true;
 #endif // defined(LEO_TARGET_MOBILE)
 
 

--- a/LeopardCommon.h
+++ b/LeopardCommon.h
@@ -186,6 +186,11 @@
 // Unroll inner loops 4 times
 #define LEO_USE_VECTOR4_OPT
 
+// MacOS M1
+#if defined(__aarch64__)
+  #define LEO_USE_SSE2NEON
+  #define LEO_TARGET_MOBILE
+#endif
 
 //------------------------------------------------------------------------------
 // Debug
@@ -256,6 +261,8 @@
     // Note: MSVC currently only supports SSSE3 but not AVX2
     #include <tmmintrin.h> // SSSE3: _mm_shuffle_epi8
     #include <emmintrin.h> // SSE2
+#elif defined(LEO_USE_SSE2NEON)
+    #include "sse2neon/sse2neon.h"
 #endif // LEO_TARGET_MOBILE
 
 #if defined(HAVE_ARM_NEON_H)
@@ -270,6 +277,8 @@
     // Compiler-specific 128-bit SIMD register keyword
     #define LEO_M128 uint8x16_t
     #define LEO_TRY_NEON
+#elif defined(LEO_USE_SSE2NEON)
+    #define LEO_M128 __m128i
 #else
     #define LEO_M128 uint64_t
 # endif
@@ -334,6 +343,8 @@ void InitializeCPUArch();
     extern bool CpuHasAVX2;
 # endif
     // Does CPU support SSSE3?
+    extern bool CpuHasSSSE3;
+#elif defined(LEO_USE_SSE2NEON)
     extern bool CpuHasSSSE3;
 #endif // LEO_TARGET_MOBILE
 


### PR DESCRIPTION
This is a cherrypick of https://github.com/status-im/leopard/pull/1

Updates https://github.com/celestiaorg/leopard/issues/2

> There was already some NEON support, through a separate code
> path. This version relies on the sse2neon library to add
> Neon support
> 
> Signed-off-by: Csaba Kiraly <csaba.kiraly@gmail.com>